### PR TITLE
✨ JiraのメンションをDMでSlackに通知できるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,4 @@ Session.vim
 # Auto-generated tag files
 tags
 
-
+/.idea

--- a/scripts/notify-jira-mentioned.coffee
+++ b/scripts/notify-jira-mentioned.coffee
@@ -1,0 +1,54 @@
+# Use if the user name of jira and slack is different
+# "jiraName": "slackName"
+
+# map = "hhasegawa": "hhasegawa"
+
+module.exports = (robot) ->
+  sendDM = (userName, message, options) ->
+    # userName は slack のユーザー名（@hoge の場合は "hoge"）
+    # slack の userID を取得
+    client = robot.adapter.client
+    userId = client.rtm.dataStore.getUserByName(userName)?.id
+    return unless userId?
+
+    client.web.chat.postMessage(userId, message, options)
+  convertHandleName = (name) ->
+    # map[name] || name # コンバートする必要があったらONに
+    name
+  extractHandleName = (body) ->
+    temp = body.match(/\[~.+?\]/g)
+    unless temp is null
+      name = []
+      for i in temp
+        name.push("#{i}".replace(/\[|\]|~/g, ""))
+      return name
+  robot.router.post '/hubot/jira-comment-dm', (req, res) ->
+    body = req.body
+    if body.webhookEvent == 'comment_created'
+      issue = "#{body.issue.key} #{body.issue.fields.summary}"
+      url = "#{process.env.HUBOT_JIRA_URL}/browse/#{body.issue.key}"
+      author = body.comment.author.name
+      handleNameList = extractHandleName(body.comment.body)
+      unless handleNameList is null
+        attachments = [
+          {
+            fallback: "[<#{url}|#{issue}>] commented by @#{author}",
+            color: 'good',
+            pretext: "[<#{url}|#{issue}>] commented by @#{author}"
+            title: issue,
+            title_link: url,
+            fields: [
+              {
+                title: "",
+                value: "#{body.comment.body}",
+                short: false
+              }
+            ],
+            footer: author,
+            ts: new Date / 1000 | 0
+          }
+        ]
+        options = { as_user: true, link_names: 1, attachments: attachments }
+        for i in handleNameList
+          sendDM(convertHandleName(i), '', options)
+      res.send 'OK'


### PR DESCRIPTION
https://medium.com/eureka-engineering/couples%E3%81%AE%E9%96%8B%E7%99%BA%E3%82%92%E3%82%B9%E3%83%A0%E3%83%BC%E3%82%BA%E3%81%AB%E3%81%97%E3%81%A6%E3%81%8F%E3%82%8C%E3%82%8Bbot%E3%81%AE%E7%B4%B9%E4%BB%8B-%E3%81%93%E3%81%AE%E4%B8%96%E3%81%AE%E7%90%86%E3%81%AF%E3%81%99%E3%81%AA%E3%82%8F%E3%81%A1%E9%80%9F%E3%81%95%E3%81%A0%E3%81%A8%E6%80%9D%E3%81%84%E3%81%BE%E3%81%9B%E3%82%93%E3%81%8B-11a36a0040f1
三代目のJiraからSlackにメンションがバグでどうしても飛ばないので、ネコで解決できないかと思い、URLのやつを入れてみた
Jiraのウェブホックから起動するらしい

明らかにここバグるよみたいなところがあったら教えて欲しいス〜