### PR TITLE
🐛 membersに空白が含まれるのを直し、部署別のガチャをできるようにした

### DIFF
--- a/scripts/members.coffee
+++ b/scripts/members.coffee
@@ -10,10 +10,12 @@
 #
 # Commands:
 #   hubot members ls - メンバーを表示
-#   hubot members add <slack_account> <github_account> - メンバーを追加
+#   hubot members add <slack_account> <github_account> <dept> - メンバーを追加
+#   hubot members rm/-rf - メンバーをすべて削除
 #   hubot members rm <name> - メンバーを削除
 #   hubot members gacha - メンバーガチャ
-#   hubot members gacha3 - メンバー3連ガチャ
+#   hubot members gacha 3 - メンバー3連ガチャ
+#   hubot members dept-gacha <dept_name> 3 - チームメンバー3連ガチャ
 #   hubot gacha <item1 item2 item3> - ガチャ
 
 moment = require 'moment'
@@ -41,26 +43,43 @@ module.exports = (robot) ->
     members = robot.brain.get(BRAIN_KEYS_MEMBERS)
     res.send JSON.stringify members
 
-  robot.respond /members add (.+)\s+(.+)/i, (res) ->
-    name = res.match[1]
-    github = res.match[2]
+  robot.respond /members add (\S+)\s(\S+)\s(\S+)/i, (res) ->
+    name = res.match[1].trim()
+    github = res.match[2].trim()
+    dept = res.match[3].trim()
     members = robot.brain.get(BRAIN_KEYS_MEMBERS) or []
-    members.push {name, github}
+    members.push {name, github, dept}
     robot.brain.set(BRAIN_KEYS_MEMBERS, members)
     res.send "added #{name}"
     res.send JSON.stringify members
 
-  robot.respond /members rm (.+)/i, (res) ->
-    name = res.match[1]
+  robot.respond /members rm\/-rf/i, (res) ->
+    robot.brain.set(BRAIN_KEYS_MEMBERS, [])
+    res.send "removed all members!"
+
+  robot.respond /members rm (\S+)/i, (res) ->
+    name = res.match[1].trim()
     members = robot.brain.get(BRAIN_KEYS_MEMBERS) or []
     newMembers = members.filter (member)-> member.name isnt name
     robot.brain.set(BRAIN_KEYS_MEMBERS, newMembers)
     res.send "removed #{name}"
     res.send JSON.stringify newMembers
 
-  robot.respond /members gacha(\d*)$/i, (res) ->
+  robot.respond /members dept-gacha (\S+)\s*(\d*)$/i, (res) ->
     members = robot.brain.get(BRAIN_KEYS_MEMBERS) or []
-    count = Number(res.match[1] || 1)
+    dept = res.match[1].trim()
+    count = Number(res.match[2] || 1)
+
+    deptMembers = members.filter (m) -> m.dept is dept
+
+    if count in [1, NaN]
+      res.send "@#{deptMembers.random()?.name}"
+    else
+      res.send deptMembers.random(count).map(({name} = {name: null})-> "@#{name}" ).join(' -> ')
+
+  robot.respond /members gacha(\s*)(\d*)$/i, (res) ->
+    members = robot.brain.get(BRAIN_KEYS_MEMBERS) or []
+    count = Number(res.match[2] || 1)
     if count in [1, NaN]
       res.send "@#{members.random()?.name}"
     else


### PR DESCRIPTION
eg:
```
# 追加(slack, github, 部署)
neko members add oieioi oieioi dev
# 全部削除
neko members rm/-rf
# 部署ガチャ
neko members dept-gacha dev
neko members dept-gacha dev 3
```