### PR TITLE
assign時にusernameが取得できなくなっていたのを修正

### DIFF
--- a/scripts/notify-jira-assigned.coffee
+++ b/scripts/notify-jira-assigned.coffee
@@ -47,7 +47,21 @@ module.exports = (robot) ->
     return res.send 'OK' unless body.issue.fields.assignee?
     return res.send 'OK' if body.webhookEvent != 'jira:issue_created' && body.changelog.items[0].field != 'assignee'
 
-    sendDM(convertHandleName(body.issue.fields.assignee.name), 'イシューにアサインされました。確認しましょう！', body)
+    # assgineeから名前の属性が消えてしまったため、ユーザーネームを取得しに行く
+    request = require 'request'
+    # jira basic authでapiを使っている。
+    # info: https://ja.confluence.atlassian.com/cloud/api-tokens-938839638.html
+    # ↑で発行したtokenと発行した際のユーザーメールアドレスが必要
+    request.get {
+        url: body.issue.fields.assignee.self,
+        json: true,
+        auth: { user: process.env.HUBOT_JIRA_USER, pass: process.env.HUBOT_JIRA_TOKEN }
+      }, (error, responce, body) ->
+      if error or responce.statusCode != 200
+        console.log error
+        return res.send('ユーザーネームの取得に失敗しました')
+      sendDM(convertHandleName(body.name), 'イシューにアサインされました。確認しましょう！', body)
+
     res.send 'OK'
 
 


### PR DESCRIPTION
Reviewer @oieioi 

- Webhookから得られるassgineeオブジェクトからユーザーのnameを取ってくることが出来なくなった
- 代替手段として、assgineeオブジェクトからユーザーの情報が得られるURLを取得し、APIを叩いてユーザーのnameを取ることにした

coffee よく分からぬので、いい書き方とかあったらレス下さい

新しく環境変数
HUBOT_JIRA_USER　↓を取ったときにログインしていたユーザーのメアド
HUBOT_JIRA_TOKEN　Jira上で取得したapi token
が必要