### PR TITLE
Jiraのコメント内メンション通知が飛ばなかったのを修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,18 +18,18 @@
       }
     },
     "@slack/client": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@slack/client/-/client-3.16.0.tgz",
-      "integrity": "sha512-CWr7a3rTVrN5Vs8GYReRAvTourbXHOqB1zglcskj05ICH4GZL5BOAza2ARai+qc3Nz0nY08Bozi1x0014KOqlg==",
+      "version": "3.16.1-sec.2",
+      "resolved": "https://registry.npmjs.org/@slack/client/-/client-3.16.1-sec.2.tgz",
+      "integrity": "sha512-FAERJJAurczrvgShW+9V95NdVYgf8FdIexUqfBgNuToRrLRDRcWNf0nGyfKAvl2RH1ncppzJp3iXgMNJFnJXhQ==",
       "requires": {
         "async": "^1.5.0",
         "bluebird": "^3.3.3",
         "eventemitter3": "^1.1.1",
-        "https-proxy-agent": "^1.0.0",
+        "https-proxy-agent": "^2.2.0",
         "inherits": "^2.0.1",
         "lodash": "^4.13.1",
         "pkginfo": "^0.4.0",
-        "request": ">=2.0.0 <2.77.0",
+        "request": "^2.85.0",
         "retry": "^0.9.0",
         "url-join": "0.0.1",
         "winston": "^2.1.1",
@@ -38,53 +38,8 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "mime-db": {
-          "version": "1.40.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-        },
-        "mime-types": {
-          "version": "2.1.24",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-          "requires": {
-            "mime-db": "1.40.0"
-          }
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
-        },
-        "request": {
-          "version": "2.76.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
-          "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "node-uuid": "~1.4.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1"
-          }
         }
       }
     },
@@ -118,12 +73,11 @@
       }
     },
     "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
+        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -155,11 +109,6 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-    },
     "async": {
       "version": "0.9.2",
       "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -169,11 +118,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
       "version": "1.8.0",
@@ -223,9 +167,9 @@
       "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
     },
     "body-parser": {
       "version": "1.13.3",
@@ -304,23 +248,10 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.x.x"
-      }
-    },
     "bytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
       "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q="
-    },
-    "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
     "chalk": {
       "version": "1.1.3",
@@ -582,14 +513,6 @@
         "moment-timezone": "^0.5.x"
       }
     },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.x.x"
-      }
-    },
     "csrf": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
@@ -763,6 +686,19 @@
         }
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "escape-html": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
@@ -865,11 +801,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -957,31 +888,6 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
-    "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.12"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.40.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-        },
-        "mime-types": {
-          "version": "2.1.24",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-          "requires": {
-            "mime-db": "1.40.0"
-          }
-        }
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -991,22 +897,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
       "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
-    },
-    "generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "^1.0.0"
-      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -1028,24 +918,6 @@
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
-    "har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "requires": {
-        "chalk": "^1.1.1",
-        "commander": "^2.9.0",
-        "is-my-json-valid": "^2.12.4",
-        "pinkie-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
-        }
-      }
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1053,22 +925,6 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
-      }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "htmlparser2": {
       "version": "3.10.1",
@@ -1112,34 +968,13 @@
         "statuses": "1"
       }
     },
-    "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "requires": {
-        "assert-plus": "^0.2.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
       }
     },
     "hubot": {
@@ -1220,20 +1055,13 @@
       "integrity": "sha1-T7yeFhlTv3kB/cNuKnAsExA/FrI="
     },
     "hubot-slack": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/hubot-slack/-/hubot-slack-4.5.1.tgz",
-      "integrity": "sha512-2nY/ilRzlZdd+8Nks2/WZV8Ti9sdsSgRRQeAcJGje92Too+ZVCtK2q0oO3YJrYIUTevo+FMnlu8hXEv5c06urw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/hubot-slack/-/hubot-slack-4.7.1.tgz",
+      "integrity": "sha512-ieQdGv0XgdhAWjIvoY3UPi05AKV3d6XZYClX/xWGfGmK5tLFX3ZPLjJyJ6dKIXWXke7/kE47HqSACZskrt0Mcg==",
       "requires": {
-        "@slack/client": "^3.4.0",
+        "@slack/client": "3.16.1-sec.2",
         "bluebird": "^3.5.1",
-        "lodash": "^3.10.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
+        "lodash": "^4.17.10"
       }
     },
     "iconv-lite": {
@@ -1260,28 +1088,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-    },
-    "is-my-json-valid": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
-      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -1322,11 +1128,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1500,11 +1301,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
       "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -1512,11 +1308,6 @@
       "requires": {
         "boolbase": "~1.0.0"
       }
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "on-finished": {
       "version": "2.1.1",
@@ -1563,19 +1354,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
     },
     "pkginfo": {
       "version": "0.4.1",
@@ -1818,11 +1596,6 @@
       "resolved": "https://registry.npmjs.org/scoped-http-client/-/scoped-http-client-0.11.0.tgz",
       "integrity": "sha1-iH+oKoNg8V1jmlLlBOVjwVfSbXQ="
     },
-    "semver": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
-    },
     "send": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
@@ -2017,14 +1790,6 @@
         }
       }
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.x.x"
-      }
-    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -2071,11 +1836,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -2089,23 +1849,10 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
-    "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "requires": {
-        "punycode": "^1.4.1"
-      }
-    },
     "tsscmp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
       "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc="
-    },
-    "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -2202,9 +1949,9 @@
       "integrity": "sha1-L7HezUxGaqiLD5NBrzPcGv8keNU="
     },
     "winston": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
-      "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",
@@ -2216,7 +1963,7 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
       }
@@ -2229,11 +1976,6 @@
         "options": ">=0.0.5",
         "ultron": "1.0.x"
       }
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.0",
-    "hubot-slack": "^4.3.3",
+    "hubot-slack": "^4.7.1",
     "lodash": "^4.17.10",
     "moment": "^2.20.1",
     "request": "^2.88.0"

--- a/scripts/notify-jira-mentioned.coffee
+++ b/scripts/notify-jira-mentioned.coffee
@@ -1,6 +1,7 @@
 # Use if the user name of jira and slack is different
 # "jiraName": "slackName"
 BRAIN_KEYS_MEMBERS = 'members'
+request = require 'request'
 
 module.exports = (robot) ->
   sendDM = (userName, message, options) ->
@@ -18,39 +19,60 @@ module.exports = (robot) ->
     member?.name or atlassianName
 
   extractHandleName = (body) ->
-    temp = body.match(/\[~.+?\]/g)
-    unless temp is null
+    new Promise((resolve, reject) ->
+      temp = body.match(/\[~accountid:.+?\]/g)
       name = []
-      for i in temp
-        name.push("#{i}".replace(/\[|\]|~/g, ""))
-      return name
+      promises = []
+      unless temp is null
+        for i in temp
+          jira_user_id = "#{i}".replace(/\[|\]|~|accountid:/g, "")
+          promises.push(
+            new Promise((resovle_child, reject_child) ->
+              request.get {
+                url: "http://handsshare.atlassian.net/rest/api/3/user?accountId=#{jira_user_id}",
+                json: true,
+                auth: { user: process.env.HUBOT_JIRA_USER, pass: process.env.HUBOT_JIRA_TOKEN }
+              }, (error, responce, another_body) ->
+                if error or responce.statusCode != 200
+                  console.log error
+                  reject_child 'JiraIDからのユーザーネームの取得に失敗しました'
+                resovle_child another_body.name
+            ).then((value) ->
+              name.push(value)
+            )
+          )
+      Promise.all(promises).then( () ->
+        resolve name
+      ))
+
   robot.router.post '/hubot/jira-comment-dm', (req, res) ->
     body = req.body
     if body.webhookEvent == 'comment_created'
       issue = "#{body.issue.key} #{body.issue.fields.summary}"
       url = "#{process.env.HUBOT_JIRA_URL}/browse/#{body.issue.key}"
       author = body.comment.author.name
-      handleNameList = extractHandleName(body.comment.body)
-      unless handleNameList is null
-        attachments = [
-          {
-            fallback: "[<#{url}|#{issue}>] commented by @#{author}",
-            color: 'good',
-            pretext: "[<#{url}|#{issue}>] commented by @#{author}"
-            title: issue,
-            title_link: url,
-            fields: [
-              {
-                title: "",
-                value: "#{body.comment.body}",
-                short: false
-              }
-            ],
-            footer: author,
-            ts: new Date / 1000 | 0
-          }
-        ]
-        options = { as_user: true, link_names: 1, attachments: attachments }
-        for i in handleNameList
-          sendDM(convertHandleName(i), 'あなた宛のコメントがあります。確認しましょう！', options)
-      res.send 'OK'
+
+      extractHandleName(body.comment.body).then (handleNameList) ->
+        unless handleNameList is null
+          attachments = [
+            {
+              fallback: "[<#{url}|#{issue}>] commented by @#{author}",
+              color: 'good',
+              pretext: "[<#{url}|#{issue}>] commented by @#{author}"
+              title: issue,
+              title_link: url,
+              fields: [
+                {
+                  title: "",
+                  value: "#{body.comment.body}",
+                  short: false
+                }
+              ],
+              footer: author,
+              ts: new Date / 1000 | 0
+            }
+          ]
+          options = { as_user: true, link_names: 1, attachments: attachments }
+          for i in handleNameList
+            sendDM(convertHandleName(i), 'あなた宛のコメントがあります。確認しましょう！', options)
+        res.send 'OK'


### PR DESCRIPTION
原因はコメント内のユーザー名が、AccountIDに切り替わっていたこと
ユーザー名からAcountIDに切り替わっていたので、IDを元にユーザー名をフェッチしにすることに
非同期処理になるため、Promiseを使って全て終わるまで待つ仕様

毎回フェッチしているので、今後保存とかつけたい
またコメント内のユーザー名が変わってしまっているため、ここをリプレイスする機能も今後付けたい